### PR TITLE
Upgrade dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+package-lock.json
+yarn.lock
 /example/dist/
 /example/node_modules/
 /node_modules/

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "async": "^2.0.0",
     "debug": "^4.1.1",
     "flatpak-bundler": "^0.1.3",
-    "fs-extra": "^0.30.0",
+    "fs-extra": "^7.0.1",
     "lodash": "^4.13.0",
     "temp": "^0.9.0",
     "yargs": "^12.0.5"

--- a/package.json
+++ b/package.json
@@ -43,10 +43,12 @@
     "yargs": "^12.0.5"
   },
   "devDependencies": {
-    "eslint": "^3.2.2",
-    "eslint-config-standard": "^6.0.0",
-    "eslint-plugin-promise": "^3.0.0",
-    "eslint-plugin-standard": "^2.0.0",
+    "eslint": "^5.12.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "mocha": "^5.2.0",
     "retry": "^0.12.0",
     "rimraf": "^2.5.1"

--- a/package.json
+++ b/package.json
@@ -29,24 +29,26 @@
     "spec": "mocha",
     "test": "npm run clean && npm run lint && npm run spec"
   },
+  "engines": {
+    "node": ">= 6.0.0"
+  },
   "dependencies": {
-    "asar": "^0.12.0",
+    "asar": "^0.14.6",
     "async": "^2.0.0",
-    "debug": "^2.2.0",
-    "flatpak-bundler": "^0.1.0",
+    "debug": "^4.1.1",
+    "flatpak-bundler": "^0.1.3",
     "fs-extra": "^0.30.0",
     "lodash": "^4.13.0",
-    "temp": "^0.8.3",
-    "yargs": "^6.0.0"
+    "temp": "^0.9.0",
+    "yargs": "^12.0.5"
   },
   "devDependencies": {
-    "chai": "^3.4.1",
     "eslint": "^3.2.2",
     "eslint-config-standard": "^6.0.0",
     "eslint-plugin-promise": "^3.0.0",
     "eslint-plugin-standard": "^2.0.0",
-    "mocha": "^3.0.0",
-    "retry": "^0.10.0",
+    "mocha": "^5.2.0",
+    "retry": "^0.12.0",
     "rimraf": "^2.5.1"
   }
 }

--- a/src/installer.js
+++ b/src/installer.js
@@ -258,12 +258,10 @@ var createApplication = function (options, dir, callback) {
   var applicationDir = path.join(dir, 'lib', options.id)
   options.logger('Copying application to ' + applicationDir)
 
-  async.waterfall([
-    async.apply(fs.ensureDir, applicationDir),
-    async.apply(fs.copy, options.src, applicationDir)
-  ], function (err) {
-    callback(err && new Error('Error copying application directory: ' + (err.message || err)))
-  })
+  return fs.ensureDir(applicationDir)
+    .then(() => fs.copy(options.src, applicationDir))
+    .then(() => callback())
+    .catch(err => callback(new Error(`Error copying application directory: ${err.message || err}`)))
 }
 
 /**

--- a/src/installer.js
+++ b/src/installer.js
@@ -30,7 +30,7 @@ var sanitizePackageNameParts = function (parts) {
 var getAppId = function (name, website) {
   var host = 'electron.atom.io'
   if (website) {
-    var urlObject = url.parse(website)
+    var urlObject = new url.URL(website)
     if (urlObject.host) host = urlObject.host
   }
   var parts = host.split('.')


### PR DESCRIPTION
* Ignore package manager lock files
* Upgrade dependencies: `fs-extra` and `eslint-plugin-node` (now required by `eslint-config-standard`) required code changes.
* Node 6 is now required (most modules dropped support for Node < 6)