### PR TITLE
fix: provide defaults for the *Flatpakref options

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "node": ">= 10.0.0"
   },
   "dependencies": {
-    "@malept/flatpak-bundler": "^0.3.0",
+    "@malept/flatpak-bundler": "^0.4.0",
     "debug": "^4.1.1",
     "electron-installer-common": "^0.10.0",
     "lodash": "^4.17.15",

--- a/src/installer.js
+++ b/src/installer.js
@@ -34,6 +34,15 @@ class FlatpakInstaller extends common.ElectronInstaller {
     return path.join(this.resourcesDir, 'desktop.ejs')
   }
 
+  get flatpakrefs () {
+    const arch = flatpak.translateArch(this.options.arch)
+    return {
+      baseFlatpakref: this.options.baseFlatpakref || `app/${this.options.base}/${arch}/${this.options.baseVersion}`,
+      runtimeFlatpakref: this.options.runtimeFlatpakref || `runtime/${this.options.runtime}/${arch}/${this.options.runtimeVersion}`,
+      sdkFlatpakref: this.options.sdkFlatpakref || `runtime/${this.options.sdk}/${arch}/${this.options.runtimeVersion}`
+    }
+  }
+
   get resourcesDir () {
     return path.resolve(__dirname, '../resources')
   }
@@ -161,14 +170,12 @@ class FlatpakInstaller extends common.ElectronInstaller {
       command,
       modules: this.options.modules
     }, {
+      ...this.flatpakrefs,
       arch: this.options.arch,
-      baseFlatpakref: this.options.baseFlatpakref,
       bundlePath: dest,
       extraExports: extraExports,
       extraFlatpakBuilderArgs: this.options.extraFlatpakBuilderArgs,
       files: files.concat(this.options.files),
-      runtimeFlatpakref: this.options.runtimeFlatpakref,
-      sdkFlatpakref: this.options.sdkFlatpakref,
       symlinks: symlinks.concat(this.options.symlinks)
     })
   }

--- a/src/installer.js
+++ b/src/installer.js
@@ -1,16 +1,12 @@
 'use strict'
 
 const _ = require('lodash')
-const childProcess = require('child_process')
 const common = require('electron-installer-common')
 const debug = require('debug')
 const flatpak = require('@malept/flatpak-bundler')
 const { getAppID } = require('./getappid')
 const path = require('path')
-const { promisify } = require('util')
 const semver = require('semver')
-
-const exec = promisify(childProcess.exec)
 
 const defaultLogger = debug('electron-installer-flatpak')
 const defaultRename = (dest, src) => path.join(dest, src)
@@ -144,12 +140,6 @@ class FlatpakInstaller extends common.ElectronInstaller {
       extraExports.push(this.pixmapIconPath)
     }
 
-    const flatpakBundlerVersion = (await exec('flatpak-builder --version')).toString().split(' ', 2)[1]
-
-    if (flatpakBundlerVersion.split('.').map(part => Number(part)) >= [0, 9, 9]) {
-      this.options.extraFlatpakBuilderArgs.push('--assumeyes')
-    }
-
     const files = [
       [this.stagingDir, '/']
     ]
@@ -164,22 +154,22 @@ class FlatpakInstaller extends common.ElectronInstaller {
       branch: this.options.branch,
       base: this.options.base,
       baseVersion: this.options.baseVersion.toString(),
-      baseFlatpakref: this.options.baseFlatpakref,
-      extraFlatpakBuilderArgs: this.options.extraFlatpakBuilderArgs,
       runtime: this.options.runtime,
       runtimeVersion: this.options.runtimeVersion.toString(),
-      runtimeFlatpakref: this.options.runtimeFlatpakref,
       sdk: this.options.sdk,
-      sdkFlatpakref: this.options.sdkFlatpakref,
       finishArgs: this.options.finishArgs,
       command,
-      files: files.concat(this.options.files),
-      symlinks: symlinks.concat(this.options.symlinks),
-      extraExports: extraExports,
       modules: this.options.modules
     }, {
       arch: this.options.arch,
-      bundlePath: dest
+      baseFlatpakref: this.options.baseFlatpakref,
+      bundlePath: dest,
+      extraExports: extraExports,
+      extraFlatpakBuilderArgs: this.options.extraFlatpakBuilderArgs,
+      files: files.concat(this.options.files),
+      runtimeFlatpakref: this.options.runtimeFlatpakref,
+      sdkFlatpakref: this.options.sdkFlatpakref,
+      symlinks: symlinks.concat(this.options.symlinks)
     })
   }
 }


### PR DESCRIPTION
Upgrade to `@malept/flatpak-bundler@^0.4.0` (relevant to this PR: https://github.com/malept/flatpak-bundler/pull/10) & provide defaults for the `*Flatpakref` options.

Fixes #24.