### PR TITLE
ci: remove apt sources workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo add-apt-repository -y ppa:alexlarsson/flatpak
-          sudo rm /etc/apt/sources.list.d/bazel.list
           sudo apt update
           sudo apt install --no-install-recommends -y flatpak-builder elfutils
           ./test/install_runtimes.sh


### PR DESCRIPTION
No longer needed (and indeed, the file no longer exists).