### PR TITLE
fix: use zypak v2021.02

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 [Unreleased]: https://github.com/malept/electron-installer-flatpak/compare/v0.11.2...master
 
+### Fixed
+
+* Update zypak to v2021.02
+
 ## [0.11.2] - 2020-06-06
 
 [0.11.2]: https://github.com/malept/electron-installer-flatpak/compare/v0.11.1...v0.11.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-* Update zypak to v2021.02
+* Update zypak to v2021.02 (malept#40)
 
 ## [0.11.2] - 2020-06-06
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -93,7 +93,7 @@ class FlatpakInstaller extends common.ElectronInstaller {
           {
             type: 'git',
             url: 'https://github.com/refi64/zypak',
-            tag: 'v2019.11beta.3'
+            tag: 'v2021.02'
           }
         ]
       })


### PR DESCRIPTION
This should make usable flatpak packages again. Tested the resulting flatpak with Ubuntu 18.04 and Debian Buster.